### PR TITLE
Declare gDisableUWEBalance

### DIFF
--- a/NSLCompMod/source/lua/DPR/FileHooks.lua
+++ b/NSLCompMod/source/lua/DPR/FileHooks.lua
@@ -1,3 +1,6 @@
+--This global disables balance changes of the UWE Extensions
+gDisableUWEBalance = true
+
 ModLoader.SetupFileHook( "lua/ResourceTower_Server.lua", "lua/DPR/ResourceTower_Server.lua", "replace" )
 ModLoader.SetupFileHook( "lua/AlienTeam.lua", "lua/DPR/AlienTeam.lua", "replace" )
 ModLoader.SetupFileHook( "lua/TechData.lua", "lua/DPR/TechData.lua", "replace" )

--- a/NSLCompMod/source/lua/entry/dpr.entry
+++ b/NSLCompMod/source/lua/entry/dpr.entry
@@ -1,4 +1,4 @@
 modEntry = {
 	FileHooks = "lua/DPR/FileHooks.lua",
-	Priority = 1
+	Priority = 100 --make sure this is higher than any UWE extension
 }


### PR DESCRIPTION
By declaring the global gDisableUWEBalance as true the UWE Extensions won't load any balance changes.