### PR TITLE
update readme, include changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
-# NSL-CompMod
-Natural Selection 2 NSL Comp Mod
+# NSL-CompMod  
+A balance and feature mod for Natural Selection 2, used by the Natural Selection League. For more information, please visit the [NSL website](http://ensl.org).  
+This mod is on the Steam Workshop with ID [2ADC73ED](https://steamcommunity.com/sharedfiles/filedetails/?id=719090669). The code is available at this [GitHub repo](https://github.com/Steelcap/NSL-CompMod).  
+Maintained by Steelcap.
 
-A mod for the upcoming season 10 of ENSL
-Find details at ENSL.org
+## Changes  
+
+### 2016-9-22
+* Machine Gun weight decreased to match shotgun  
+* Boneshield armor regeneration per second reduced to 0  
+* Boneshield damage reduction increased to 75%  
+* Boneshield cooldown reduced to 6.25 seconds  
+* Removed the ability to drop lifeform eggs  
+* Cyst max hp reduced to 180  
+* Cyst maturation rate reduced to 10 from 45  
+* Rupture moved to Biomass 4  
+* Nutrient Mist requires infestation to place  
+* Nutrient Mist no longer preserves structures off infestation  
+* Gorge air friction reduced to 0.12 from 0.8  
+* Gorge air control increased to 30 from 8  
+* Cysts will be damaged while unconnected  
+* Removed floating health bars on players  
+* Shotgun spread increased by 33%  
+* Starting P-Res for Marines increased to 20 from 15  
+* Starting P-Res for Aliens increased to 15 from 12  
+* P-Res rate for all players decreased to 0.1 from 0.125  
+* Lerk P-Res cost increased to 20 from 18  
+* Increased Lerk armor from to 55 from 45  
+* Removed Focus  
+* Silence moved to Shade Hive from Shift Hive  
+* Softcap on all alien healing over 16% per second, reducing effectiveness by 80%  
+* Fade hitbox changes reverted, hitbox is now smaller  
+* Nerfed crush effectiveness on Lerk Spikes to 4.5% from 7%  
+* Disabled Regeneration within 3 seconds of taking damage  


### PR DESCRIPTION
The intent is for each date heading to include all changes from vanilla, with changes from previous comp mod versions marked in some way (e.g. bolded). That way people don't have to read the entire changelog to see the difference between comp and vanilla, but you can still track how the mod evolved.