### PR TITLE
Remove area damage from pre-game spawn rooms

### DIFF
--- a/NSLCompMod/source/lua/DPR/FileHooks.lua
+++ b/NSLCompMod/source/lua/DPR/FileHooks.lua
@@ -22,6 +22,7 @@ ModLoader.SetupFileHook( "lua/BalanceMisc.lua", "lua/DPR/BalanceMisc.lua", "post
 ModLoader.SetupFileHook( "lua/DamageTypes.lua", "lua/DPR/DamageTypes.lua", "post" )
 ModLoader.SetupFileHook( "lua/GhostModelUI.lua", "lua/DPR/GhostModelUI.lua", "post" )
 ModLoader.SetupFileHook( "lua/Gorge.lua", "lua/DPR/Gorge.lua", "post" )
+ModLoader.SetupFileHook( "lua/NS2Gamerules.lua", "lua/DPR/NS2Gamerules.lua", "post")
 ModLoader.SetupFileHook( "lua/NS2Utility_Server.lua", "lua/DPR/NS2Utility_Server.lua", "post" )
 ModLoader.SetupFileHook( "lua/Player_Client.lua", "lua/DPR/Player_Client.lua", "post" )
 ModLoader.SetupFileHook( "lua/Weapons/Marine/Shotgun.lua", "lua/DPR/Shotgun.lua", "post" )

--- a/NSLCompMod/source/lua/DPR/NS2Gamerules.lua
+++ b/NSLCompMod/source/lua/DPR/NS2Gamerules.lua
@@ -1,0 +1,22 @@
+    function NS2Gamerules:KillEnemiesNearCommandStructureInPreGame(timePassed)
+    
+        if self:GetGameState() < kGameState.Countdown then
+        
+            local commandStations = Shared.GetEntitiesWithClassname("CommandStructure")
+            for _, ent in ientitylist(commandStations) do
+            
+                local enemyPlayers = GetEntitiesForTeam("Player", GetEnemyTeamNumber(ent:GetTeamNumber()))
+                for e = 1, #enemyPlayers do
+                
+                    local enemy = enemyPlayers[e]
+                    if enemy:GetDistance(ent) <= 5 then
+                        enemy:TakeDamage(25 * timePassed, nil, nil, nil, nil, 0, 25 * timePassed, kDamageType.Normal)
+                    end
+                    
+                end
+                
+            end
+            
+        end
+        
+    end

--- a/README.md
+++ b/README.md
@@ -4,6 +4,47 @@ This mod is on the Steam Workshop with ID [2ADC73ED](https://steamcommunity.com/
 Maintained by Steelcap.
 
 ## Changes
+### 2017-1-19 
+* Removed floating health bars on players  
+* P-Res rate for all players decreased to 0.1 from 0.125  
+* Disallowed seeing who is enemy commander in pregame  
+* **Pregame damage only occurs when touching enemy chair/hive**  
+
+###### Aliens  
+* Starting P-Res for Aliens increased to 15 from 12  
+* Removed Focus  
+* Onos cost 55 P-Res
+* Silence moved to Shade Hive from Shift Hive   
+* Disabled Regeneration within 3 seconds of taking damage  
+* No longer posible to trigger evolution egg without actual changes in evolution  
+* Remove alien abilities if required biomass is lost from hive death  
+* Soft cap on all alien healing over 16% per second, reducing effectiveness by 80%  
+* Rupture moved to Biomass 4  
+* Nutrient Mist requires infestation to place  
+* Nutrient Mist no longer preserves structures off infestation  
+* Cysts will be damaged while unconnected  
+* Cyst max hp reduced to 180  
+* Cyst maturation rate reduced to 10 from 45  
+* Removed the ability to drop lifeform eggs   
+* Skulks do not gain health from biomass after biomass 4 (84 hp)  
+* Gorges can now control which tunnel will be replaced when they place their third tunnel by crouching while placing it**  
+* Gorge air friction reduced to 0.12 from 0.8  
+* Gorge air control increased to 30 from 8  
+* Gorge belly slide friction off-infestation increased to 0.2 from 0.1
+* Lerk P-Res cost increased to 20 from 18  
+* Nerfed crush effectiveness on Lerk Spikes to 4.5% from 7%  
+* Fade hitbox changes reverted, hitbox is now smaller  
+* Boneshield armor regeneration per second reduced to 0  
+* Boneshield damage reduction increased to 75%  
+* Boneshield cooldown reduced to 6.25 seconds  
+
+###### Marines  
+* Starting P-Res for Marines increased to 20 from 15  
+* Shotgun spread adjusted from +33% to +10%  
+* Increased Mine hp to 40 from 20. Mines now detonate to 5 parasites instead of 3.  
+* Mine damage increased to 140 from 125  
+* Machine Gun weight decreased to match shotgun  
+  
 ### 2016-12-2 
 * Removed floating health bars on players  
 * P-Res rate for all players decreased to 0.1 from 0.125  


### PR DESCRIPTION
Instead of the entire room dealing damage, only the chair and hive deal damage.
This is how it was before vanilla build 306.