### PR TITLE
New Changes for Build 325

### DIFF
--- a/NSLCompMod/source/lua/DPR/Post/Balance.lua
+++ b/NSLCompMod/source/lua/DPR/Post/Balance.lua
@@ -25,7 +25,7 @@ kTechMed2ResearchTime = 90
 
 --new changes
 
-kShotgunSpreadDistance = 8.25 -- from 8.5 to 9.25
+kShotgunSpreadDistance = 8.88
 
 --mine changes
 kMineDamage = 150 -- from 125 to 150

--- a/NSLCompMod/source/lua/DPR/Post/BalanceMisc.lua
+++ b/NSLCompMod/source/lua/DPR/Post/BalanceMisc.lua
@@ -18,8 +18,8 @@ kARCSupply = 15
 kSentrySupply = 10
 kRoboticsFactorySupply = 10
 
-kSentryBatterySupply = 20
-kObservatorySupply = 30
+kSentryBatterySupply = 10
+kObservatorySupply = 40
 
 -- Increases the delay between alien attacks by the given value in percentage while using the Focus upgrade.
 kFocusAttackSlowAtMax = 0.05

--- a/NSLCompMod/source/lua/DPR/Post/Embryo.lua
+++ b/NSLCompMod/source/lua/DPR/Post/Embryo.lua
@@ -1,0 +1,223 @@
+
+local kMinGestationTime = 1
+local kUpdateGestationTime = 0.1
+
+
+local function UpdateGestation(self)
+
+    -- Cannot spawn unless alive.
+    if self:GetIsAlive() and self.gestationClass ~= nil then
+    
+        if not self.gestateEffectsTriggered then
+        
+            self:TriggerEffects("player_start_gestate")
+            self.gestateEffectsTriggered = true
+            
+        end
+        
+        -- Take into account catalyst effects
+        local amount = GetAlienCatalystTimeAmount(kUpdateGestationTime, self)
+        self.evolveTime = self.evolveTime + kUpdateGestationTime + amount
+        
+        self.evolvePercentage = Clamp((self.evolveTime / self.gestationTime) * 100, 0, 100)
+        
+        if self.evolveTime >= self.gestationTime then
+
+            -- Replace player with new player
+            local newPlayer = self:Replace(self.gestationClass)
+            newPlayer:SetCameraDistance(0)
+            
+            local capsuleHeight, capsuleRadius = self:GetTraceCapsule()
+            local newAlienExtents = LookupTechData(newPlayer:GetTechId(), kTechDataMaxExtents)
+
+            -- Add a bit to the extents when looking for a clear space to spawn.
+            local spawnBufferExtents = Vector(0.1, 0.1, 0.1)
+            
+            --validate the spawn point before using it
+            if self.validSpawnPoint and GetHasRoomForCapsule(newAlienExtents + spawnBufferExtents, self.validSpawnPoint + Vector(0, newAlienExtents.y + Embryo.kEvolveSpawnOffset, 0), CollisionRep.Default, PhysicsMask.AllButPCsAndRagdolls, nil, EntityFilterTwo(self, newPlayer)) then
+                newPlayer:SetOrigin(self.validSpawnPoint)
+            else
+                for index = 1, 100 do
+
+                    local spawnPoint = GetRandomSpawnForCapsule(newAlienExtents.y, capsuleRadius, self:GetModelOrigin(), 0.5, 5, EntityFilterOne(self))
+
+                    if spawnPoint then
+
+                        newPlayer:SetOrigin(spawnPoint)
+                        break
+
+                    end
+
+                end
+
+            end
+
+            newPlayer:DropToFloor()
+            
+            self:TriggerEffects("player_end_gestate")
+            
+            -- Now give new player all the upgrades they purchased
+            local upgradesGiven = 0
+            
+            for index, upgradeId in ipairs(self.evolvingUpgrades) do
+
+                if newPlayer:GiveUpgrade(upgradeId) then
+                    upgradesGiven = upgradesGiven + 1
+                end
+                
+            end
+
+            local healthScalar = self.storedHealthScalar or 1
+            local armorScalar = self.storedArmorScalar or 1
+
+            newPlayer:SetHealth(healthScalar * LookupTechData(self.gestationTypeTechId, kTechDataMaxHealth))
+            newPlayer:SetArmor(armorScalar * LookupTechData(self.gestationTypeTechId, kTechDataMaxArmor))
+
+            newPlayer:UpdateArmorAmount()
+            newPlayer:SetHatched()
+            newPlayer:TriggerEffects("egg_death")
+            
+            if self.resOnGestationComplete then
+                newPlayer:AddResources(self.resOnGestationComplete)
+            end
+            
+            local newUpgrades = newPlayer:GetUpgrades()
+            if #newUpgrades > 0 then
+                local class = newPlayer:GetClassName()
+                newPlayer.lastUpgradeList = newPlayer.lastUpgradeList or {}
+                newPlayer.lastUpgradeList[class] = newPlayer:GetUpgrades()
+            end
+
+            -- Notify team
+
+            local team = self:GetTeam()
+
+            if team and team.OnEvolved then
+
+                team:OnEvolved(newPlayer:GetTechId())
+
+                for _, upgradeId in ipairs(self.evolvingUpgrades) do
+
+                    if team.OnEvolved then
+                        team:OnEvolved(upgradeId)
+                    end
+                    
+                end
+
+            end
+            
+            -- Return false so that we don't get called again if the server time step
+            -- was larger than the callback interval
+            return false
+            
+        end
+        
+    end
+    
+    return true
+    
+end
+
+function Embryo:SetGestationData(techIds, previousTechId, healthScalar, armorScalar)
+
+    -- Save upgrades so they can be given when spawned
+    self.evolvingUpgrades = {}
+    table.copy(techIds, self.evolvingUpgrades)
+
+    self.gestationClass = nil
+    
+    for i, techId in ipairs(techIds) do
+        self.gestationClass = LookupTechData(techId, kTechDataGestateName)
+        if self.gestationClass then 
+            -- Remove gestation tech id from "upgrades"
+            self.gestationTypeTechId = techId
+            table.removevalue(self.evolvingUpgrades, self.gestationTypeTechId)
+            break 
+        end
+    end
+    
+    -- Upgrades don't have a gestate name, we want to gestate back into the
+    -- current alien type, previousTechId.
+    if not self.gestationClass then
+        self.gestationTypeTechId = previousTechId
+        self.gestationClass = LookupTechData(previousTechId, kTechDataGestateName)
+    end
+    self.gestationStartTime = Shared.GetTime()
+    
+    local lifeformTime = ConditionalValue(self.gestationTypeTechId ~= previousTechId, self:GetGestationTime(self.gestationTypeTechId), 0)
+    
+    local newUpgradesAmount = 0    
+    local currentUpgrades = self:GetUpgrades()
+    
+    for _, upgradeId in ipairs(self.evolvingUpgrades) do
+
+        if not table.icontains(currentUpgrades, upgradeId) then
+            newUpgradesAmount = newUpgradesAmount + 1
+        end
+        
+    end
+
+    self.gestationTime = ConditionalValue(Shared.GetDevMode() or GetGameInfoEntity():GetWarmUpActive(), 1, lifeformTime + newUpgradesAmount * kUpgradeGestationTime)
+    
+    self.gestationTime = math.max(kMinGestationTime, self.gestationTime)
+
+    if Embryo.gFastEvolveCheat then
+        self.gestationTime = 5
+    end
+    
+    self.evolveTime = 0
+    
+    local maxHealth = LookupTechData(self.gestationTypeTechId, kTechDataMaxHealth) * 0.3 + 100
+    maxHealth = math.round(maxHealth * 0.1) * 10
+
+    self:SetMaxHealth(maxHealth)
+    self:SetHealth(maxHealth * healthScalar)
+    self:SetMaxArmor(0)
+    self:SetArmor(0)
+
+    self.storedHealthScalar = healthScalar
+    self.storedArmorScalar = armorScalar
+
+    -- === End === 
+
+    -- we reset the upgrades entirely and set them again, simplifies the code
+    self:ClearUpgrades()
+
+end
+
+function Embryo:OnInitialized()
+
+    InitMixin(self, GroundMoveMixin)
+    InitMixin(self, CameraHolderMixin, { kFov = kEmbryoFov })
+    
+    Alien.OnInitialized(self)
+    
+    self:SetModel(Embryo.kModelName, Embryo.kAnimationGraph)
+    
+    if Server then
+        self:AddTimedCallback(UpdateGestation, kUpdateGestationTime)
+    end
+    
+    self.originalAngles = Angles(self:GetAngles())
+
+    if Client and Client.GetLocalPlayer() == self then
+    
+        if Client.GetOptionBoolean(kInvertedMouseOptionsKey, false) then
+            Client.SetPitch(-0.8)
+        else
+            Client.SetPitch(0.8)
+        end
+
+        
+    end
+    
+    -- do not animate the camera transition, just teleport instantly.
+    self:SetCameraDistance(kGestateCameraDistance)
+    self:SetViewOffsetHeight(.5)
+    
+    if not Predict then
+        InitMixin(self, AlienStructureVariantMixin)
+        self:ForceStructureSkinsUpdate()
+    end
+
+end

--- a/NSLCompMod/source/lua/DPR/Post/FireMixin.lua
+++ b/NSLCompMod/source/lua/DPR/Post/FireMixin.lua
@@ -1,4 +1,5 @@
-local kClusterGrenadeBurnDuration = 4
+local kClusterBurnDurationStructure = 2
+local kClusterBurnDurationPlayer = 4
 local kBurnUpdateRate = 0.5 -- same as vanilla
 
 -- fire from cluster grenades burns for less time
@@ -48,11 +49,6 @@ local function SharedUpdate(self, deltaTime)
 
         end
 
-        -- Check what burned us, change the burn time
-        if self.fireDoerName == ClusterGrenade.kMapName then
-            self.timeBurnDuration = kClusterGrenadeBurnDuration
-        end
-
         -- See if we put ourselves out
         if time - self.timeBurnRefresh > self.timeBurnDuration then
             self:SetGameEffectMask(kGameEffect.OnFire, false)
@@ -81,14 +77,6 @@ function FireMixin:SetOnFire(attacker, doer)
 
         if doer then
             self.fireDoerId = doer:GetId()
-
-            -- Store the name of what burned us
-            -- Not a general solution but works for now
-            if doer:isa("ClusterGrenade") then 
-                self.fireDoerName = ClusterGrenade.kMapName
-            else
-                self.fireDoerName = Flamethrower.kMapName
-            end
         end
 
         local time = Shared.GetTime()
@@ -97,10 +85,18 @@ function FireMixin:SetOnFire(attacker, doer)
         self.isOnFire = true
         
         --Flat restriction to single-shot player burn time. ideally will diminish "burn-out" deaths
-        if self:isa("Player") then
-            self.timeBurnDuration = kFlamethrowerBurnDuration
+        if doer and doer:isa("ClusterGrenade") then
+            if self:isa("Player") then
+                self.timeBurnDuration = kClusterBurnDurationPlayer
+            else
+                self.timeBurnDuration = kClusterBurnDurationStructure
+            end
         else
-            self.timeBurnDuration = math.min(self.timeBurnDuration + kFlamethrowerBurnDuration, kFlamethrowerMaxBurnDuration)
+            if self:isa("Player") then
+                self.timeBurnDuration = kFlamethrowerBurnDuration
+            else
+                self.timeBurnDuration = math.min(self.timeBurnDuration + kFlamethrowerBurnDuration, kFlamethrowerMaxBurnDuration)
+            end
         end
     end
 end

--- a/NSLCompMod/source/lua/DPR/Shared/Egg.lua
+++ b/NSLCompMod/source/lua/DPR/Shared/Egg.lua
@@ -1,0 +1,41 @@
+function Egg:GetMaturityRate()
+	return kEggMaturationTime
+end
+
+function Egg:GetMatureMaxHealth()
+	return kMatureEggHealth
+end
+
+function Egg:GetMatureMaxArmor()
+	return kMatureEggArmor
+end
+
+if Server then
+
+	local function GestatePlayer(self, player, fromTechId)
+
+   		player.oneHive = false
+	    player.twoHives = false
+	    player.threeHives = false
+
+	    -- local playerHealthScalar = player:GetHealthScalar()
+	    -- local playerArmorScalar = player:GetArmorScalar()
+	    local newPlayer = player:Replace(Embryo.kMapName)
+	    if not newPlayer:IsAnimated() then
+	        newPlayer:SetDesiredCamera(1.1, { follow = true, tweening = kTweeningFunctions.easeout7 })
+	    end
+	    newPlayer:SetCameraDistance(kGestateCameraDistance)
+	    
+	    -- Eliminate velocity so that we don't slide or jump as an egg
+	    newPlayer:SetVelocity(Vector(0, 0, 0))
+	    
+	    newPlayer:DropToFloor()
+	    
+	    local techIds = { self:GetGestateTechId() }
+	    -- newPlayer:SetGestationData(techIds, fromTechId, playerHealthScalar, playerArmorScalar)
+	    newPlayer:SetGestationData(techIds, fromTechId, 1, 1)
+
+	end
+
+	ReplaceLocals(Egg.OnUse, {GestatePlayer = GestatePlayer})
+end

--- a/NSLCompMod/source/lua/DPR/Shared/GasGrenade.lua
+++ b/NSLCompMod/source/lua/DPR/Shared/GasGrenade.lua
@@ -1,0 +1,6 @@
+
+local kLifeTime = 7.5 -- 10
+local kNerveGasCloudLifetime = 4.5 -- 6
+
+ReplaceLocals(GasGrenade.OnCreate, {kLifeTime = kLifeTime})
+ReplaceLocals(NerveGasCloud.OnCreate, {kNerveGasCloudLifetime = kNerveGasCloudLifetime})

--- a/NSLCompMod/source/lua/DPR/Shared/Hive_Server.lua
+++ b/NSLCompMod/source/lua/DPR/Shared/Hive_Server.lua
@@ -1,0 +1,22 @@
+local function UpdateHealing(self)
+
+    if GetIsUnitActive(self) and not self:GetGameEffectMask(kGameEffect.OnFire) then
+
+        if self.timeOfLastHeal == nil or Shared.GetTime() > (self.timeOfLastHeal + Hive.kHealthUpdateTime) then
+
+            local players = GetEntitiesForTeam("Player", self:GetTeamNumber())
+            for index, player in ipairs(players) do
+                if player:GetIsAlive()and ((player:GetOrigin() - self:GetOrigin()):GetLength() < Hive.kHealRadius) then
+                    player:AddHealth(math.max(10, player:GetMaxHealth() * Hive.kHealthPercentage), true)
+                end
+            end
+
+            self.timeOfLastHeal = Shared.GetTime()
+
+        end
+
+    end
+
+end
+
+ReplaceLocals(Hive.OnUpdate, {UpdateHealing = UpdateHealing})


### PR DESCRIPTION
New Comp changes for build 325
- Supply changes:
  - Observatory supply cost to 40 from 30
  - Sentry battery supply cost to 10 from 20
- Shotgun spread to 8.88
- Cluster grenade flame duration:
  - Flame duration against players to 4 seconds
  - Flame duration against structures to 2 seconds
- Gas grenade duration changed to 3/4 of the vanilla value
- Egg changes:
  - eHP of lifeform eggs scale with lifeform hp again
  - Hives only heal players, not eggs.